### PR TITLE
fix downloading of all surveys

### DIFF
--- a/inst/dev/dl_all_surveys.r
+++ b/inst/dev/dl_all_surveys.r
@@ -10,11 +10,11 @@ dir.create(here("surveys"), showWarnings = FALSE)
 ## save them in the `surveys` folder (which is created if it does not exist)
 tic()
 survey_files <- purrr::map(ls$url, function(x) {
+  Sys.sleep(10)
   download_survey(
     survey = x,
     dir = "surveys"
   )
-  Sys.sleep(10)
 })
 toc()
 ## name list elements according to url


### PR DESCRIPTION
The `sleep()` call means the list of files isn't returned so `survey_files.rds` doesn't contain the relevant information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted the timing of delays during survey downloads to occur before each download instead of after. No changes to visible features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->