### PR TITLE
Remove duplicate links from zenodo scraping 

### DIFF
--- a/R/download_survey.R
+++ b/R/download_survey.R
@@ -86,10 +86,11 @@ download_survey <- function(survey, dir = NULL, sleep = 1) {
   }
   reference[[ifelse(is.doi, "doi", "url")]] <- survey
 
-  links <- xml_attr(
-    xml_find_all(parsed_body, "//link[@type='text/csv']"),
-    "href"
-  )
+  links <- xml_find_all(
+    parsed_body,
+    "//link[@type='text/csv' and @rel='item']"
+  ) |>
+    xml_attr("href")
 
   zenodo_links <- data.table(url = links)
   ## only download csv files


### PR DESCRIPTION
by using an additional XML search (@rel='item'). Resolves #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSV file link extraction to ensure only relevant links are selected, enhancing accuracy when downloading survey files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->