### PR TITLE
install package

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr, any::xml2
+          extra-packages: any::covr, any::xml2, local::.
           needs: coverage
 
       - name: Test coverage


### PR DESCRIPTION
Fixes #45.

Needed to pass tests that rely on the installed package for locating the right directory in which to save contact surveys.

This will still fail locally for a user who hasn't installed the package and instead uses e.g. `devtools::load_all()` but I think that's a breakage we might be able to accept.