### PR TITLE
Fix breaking covr test

### DIFF
--- a/tests/testthat/test-contactsurveys-dir.R
+++ b/tests/testthat/test-contactsurveys-dir.R
@@ -3,19 +3,22 @@ test_that("contactsurveys_dir()", {
   expect_identical(x, Sys.getenv("CONTACTSURVEYS_HOME"))
 })
 
-test_that("contactsurveys_dir() falls back to R_user_dir when env unset", {
+test_that("contactsurveys_dir() falls back to R_user_dir when env set to NA", {
   withr::local_envvar(CONTACTSURVEYS_HOME = NA_character_)
   p <- contactsurveys_dir()
   expect_true(nzchar(p))
-  expect_true(
-    file.exists(p),
-    info = "contactsurveys_dir() provides a real path"
+  expect_identical(
+    p,
+    tools::R_user_dir("contactsurveys")
   )
 })
 
-test_that("empty CONTACTSURVEYS_HOME falls back and creates dir", {
+test_that("empty CONTACTSURVEYS_HOME falls back to R_user_dir when env empty", {
   withr::local_envvar(CONTACTSURVEYS_HOME = "")
   p <- contactsurveys_dir()
   expect_true(nzchar(p))
-  expect_true(file.exists(p))
+  expect_identical(
+    p,
+    tools::R_user_dir("contactsurveys")
+  )
 })


### PR DESCRIPTION
Use file.exists not dir.exists since contactsurveys_dir() doesn't create a directory

Resolves #45 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated tests to assert explicit fallback to the R user directory when the related environment variable is unset, empty, or NA.
  * Clarified test names and expectations to better describe fallback semantics.
  * No changes to product behavior; these are test-only updates that improve confidence and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->