### PR TITLE
add ORCID - resolves #61

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,17 +2,17 @@ Package: contactsurveys
 Title: Download Contact Surveys for use in Infectious Disease Modelling
 Version: 0.0.0.9000
 Authors@R: c(
-    person("Sebastian", "Funk", , "sebastian.funk@lshtm.ac.uk", role = c("aut", "cre")),
-    person("Lander", "Willem", role = "aut"),
-    person("Hugo", "Gruson", role = "aut"),
-    person("Maria", "Bekker-Nielsen Dunbar", role = "ctb"),
-    person("Carl A. B.", "Pearson", role = "ctb"),
-    person("Sam", "Clifford", , "sj.clifford@gmail.com", role = "ctb"),
-    person("Christopher", "Jarvis", role = "ctb"),
-    person("Alexis", "Robert", , "alexis.robert@lshtm.ac.uk", role = "ctb"),
-    person("Niel", "Hens", role = "ctb"),
-    person("Pietro", "Coletti", role = c("col", "dtm")),
-    person("Nicholas", "Tierney", , "nicholas.tierney@gmail.com", role = c("aut"))
+    person("Sebastian", "Funk", , "sebastian.funk@lshtm.ac.uk", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-2842-3406")),
+    person("Lander", "Willem", role = "aut", comment = c(ORCID = "0000-0002-9210-1196")),
+    person("Hugo", "Gruson", role = "aut", comment = c(ORCID = "0000-0002-4094-1476")),
+    person("Maria", "Bekker-Nielsen Dunbar", role = "ctb", comment = c(ORCID = "0000-0002-7249-3524")),
+    person("Carl A. B.", "Pearson", role = "ctb", comment = c(ORCID = "0000-0003-0701-7860")),
+    person("Sam", "Clifford", , "sj.clifford@gmail.com", role = "ctb", comment = c(ORCID = "0000-0002-3774-3882")),
+    person("Christopher", "Jarvis", role = "ctb", comment = c(ORCID = "0000-0002-0812-2446")),
+    person("Alexis", "Robert", , "alexis.robert@lshtm.ac.uk", role = "ctb", comment = c(ORCID = "0000-0002-4516-2965")),
+    person("Niel", "Hens", role = "ctb", comment = c(ORCID = "0000-0003-1881-0637")),
+    person("Pietro", "Coletti", role = c("col", "dtm"), comment = c(ORCID = "0000-0001-9935-1692")),
+    person("Nicholas", "Tierney", , "nicholas.tierney@gmail.com", role = c("aut"), comment = c(ORCID = "0000-0003-1460-8722"))
   )
 Description: Provides methods for downloading contact surveys that are then 
   used in infectious disease modelling.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,17 +2,76 @@ Package: contactsurveys
 Title: Download Contact Surveys for use in Infectious Disease Modelling
 Version: 0.0.0.9000
 Authors@R: c(
-    person("Sebastian", "Funk", , "sebastian.funk@lshtm.ac.uk", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-2842-3406")),
-    person("Lander", "Willem", role = "aut", comment = c(ORCID = "0000-0002-9210-1196")),
-    person("Hugo", "Gruson", role = "aut", comment = c(ORCID = "0000-0002-4094-1476")),
-    person("Maria", "Bekker-Nielsen Dunbar", role = "ctb", comment = c(ORCID = "0000-0002-7249-3524")),
-    person("Carl A. B.", "Pearson", role = "ctb", comment = c(ORCID = "0000-0003-0701-7860")),
-    person("Sam", "Clifford", , "sj.clifford@gmail.com", role = "ctb", comment = c(ORCID = "0000-0002-3774-3882")),
-    person("Christopher", "Jarvis", role = "ctb", comment = c(ORCID = "0000-0002-0812-2446")),
-    person("Alexis", "Robert", , "alexis.robert@lshtm.ac.uk", role = "ctb", comment = c(ORCID = "0000-0002-4516-2965")),
-    person("Niel", "Hens", role = "ctb", comment = c(ORCID = "0000-0003-1881-0637")),
-    person("Pietro", "Coletti", role = c("col", "dtm"), comment = c(ORCID = "0000-0001-9935-1692")),
-    person("Nicholas", "Tierney", , "nicholas.tierney@gmail.com", role = c("aut"), comment = c(ORCID = "0000-0003-1460-8722"))
+    person(
+      given = "Sebastian", 
+      family = "Funk",
+      email = "sebastian.funk@lshtm.ac.uk", 
+      role = c("aut", "cre"), 
+      comment = c(ORCID = "0000-0002-2842-3406")
+      ),
+    person(
+      given = "Lander", 
+      family = "Willem", 
+      role = "aut", 
+      comment = c(ORCID = "0000-0002-9210-1196")
+      ),
+    person(
+      given = "Hugo", 
+      family = "Gruson", 
+      role = "aut", 
+      comment = c(ORCID = "0000-0002-4094-1476")
+      ),
+    person(
+      given = "Maria", 
+      family = "Bekker-Nielsen Dunbar",
+      role = "ctb", 
+      comment = c(ORCID = "0000-0002-7249-3524")
+      ),
+    person(
+      given = "Carl A. B.", 
+      family = "Pearson", 
+      role = "ctb", 
+      comment = c(ORCID = "0000-0003-0701-7860")
+      ),
+    person(
+      given = "Sam", 
+      family = "Clifford",
+      email = "sj.clifford@gmail.com", 
+      role = "ctb", 
+      comment = c(ORCID = "0000-0002-3774-3882")
+      ),
+    person(
+      given = "Christopher", 
+      family = "Jarvis", 
+      role = "ctb", 
+      comment = c(ORCID = "0000-0002-0812-2446")
+      ),
+    person(
+      given = "Alexis", 
+      family = "Robert",
+      email = "alexis.robert@lshtm.ac.uk", 
+      role = "ctb", 
+      comment = c(ORCID = "0000-0002-4516-2965")
+      ),
+    person(
+      given = "Niel", 
+      family = "Hens", 
+      role = "ctb", 
+      comment = c(ORCID = "0000-0003-1881-0637")
+      ),
+    person(
+      given = "Pietro", 
+      family = "Coletti", 
+      role = c("col", "dtm"), 
+      comment = c(ORCID = "0000-0001-9935-1692")
+      ),
+    person(
+      given = "Nicholas", 
+      family = "Tierney",
+      email = "nicholas.tierney@gmail.com", 
+      role = c("aut"), 
+      comment = c(ORCID = "0000-0003-1460-8722")
+      )
   )
 Description: Provides methods for downloading contact surveys that are then 
   used in infectious disease modelling.

--- a/man/contactsurveys-package.Rd
+++ b/man/contactsurveys-package.Rd
@@ -18,23 +18,24 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Sebastian Funk \email{sebastian.funk@lshtm.ac.uk}
+\strong{Maintainer}: Sebastian Funk \email{sebastian.funk@lshtm.ac.uk} (\href{https://orcid.org/0000-0002-2842-3406}{ORCID})
 
 Authors:
 \itemize{
-  \item Lander Willem
-  \item Hugo Gruson
+  \item Lander Willem (\href{https://orcid.org/0000-0002-9210-1196}{ORCID})
+  \item Hugo Gruson (\href{https://orcid.org/0000-0002-4094-1476}{ORCID})
+  \item Nicholas Tierney \email{nicholas.tierney@gmail.com} (\href{https://orcid.org/0000-0003-1460-8722}{ORCID})
 }
 
 Other contributors:
 \itemize{
-  \item Maria Bekker-Nielsen Dunbar [contributor]
-  \item Carl A. B. Pearson [contributor]
-  \item Sam Clifford \email{sj.clifford@gmail.com} [contributor]
-  \item Christopher Jarvis [contributor]
-  \item Alexis Robert \email{alexis.robert@lshtm.ac.uk} [contributor]
-  \item Niel Hens [contributor]
-  \item Pietro Coletti [collector, data manager]
+  \item Maria Bekker-Nielsen Dunbar (\href{https://orcid.org/0000-0002-7249-3524}{ORCID}) [contributor]
+  \item Carl A. B. Pearson (\href{https://orcid.org/0000-0003-0701-7860}{ORCID}) [contributor]
+  \item Sam Clifford \email{sj.clifford@gmail.com} (\href{https://orcid.org/0000-0002-3774-3882}{ORCID}) [contributor]
+  \item Christopher Jarvis (\href{https://orcid.org/0000-0002-0812-2446}{ORCID}) [contributor]
+  \item Alexis Robert \email{alexis.robert@lshtm.ac.uk} (\href{https://orcid.org/0000-0002-4516-2965}{ORCID}) [contributor]
+  \item Niel Hens (\href{https://orcid.org/0000-0003-1881-0637}{ORCID}) [contributor]
+  \item Pietro Coletti (\href{https://orcid.org/0000-0001-9935-1692}{ORCID}) [collector, data manager]
 }
 
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added ORCID identifiers for all authors, contributors, and the maintainer in package metadata and reference documentation to improve attribution and discoverability. No functional changes.

- Chores
  - Standardized author entries to explicit named fields and appended ORCID metadata while preserving existing roles and emails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->