### PR TITLE
Fixed verbosity issue by importing purrr::quietly

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -82,6 +82,7 @@ Imports:
     cli (>= 3.6.0),
     data.table,
     oai,
+    purrr,
     rlang (>= 1.0.0),
     zen4R (>= 0.10.3)
 Suggests:

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,3 +4,4 @@
 * Added verbosity to `list_surveys()`
 * Added `get_citation()` - Resolves #38
 * Added bibtex citation style as default to `get_citation()` - Resolves #52
+* Fixed verbosity issue by importing purrr::quietly - Resolves #68

--- a/R/download_survey.R
+++ b/R/download_survey.R
@@ -45,12 +45,13 @@ download_survey <- function(
       timeout = timeout
     )
   } else {
-    suppressMessages(.download_survey(
+    quiet_download_survey <- purrr::quietly(.download_survey)
+    quiet_download_survey(
       survey = survey,
       directory = directory,
       overwrite = overwrite,
       timeout = timeout
-    ))
+    )
   }
 }
 

--- a/R/download_survey.R
+++ b/R/download_survey.R
@@ -51,7 +51,7 @@ download_survey <- function(
       directory = directory,
       overwrite = overwrite,
       timeout = timeout
-    )
+    )$result
   }
 }
 

--- a/R/lists.R
+++ b/R/lists.R
@@ -18,9 +18,8 @@ list_surveys <- function(
   if (verbose) {
     .list_surveys(directory = directory, overwrite = overwrite)
   } else {
-    suppressMessages(
-      .list_surveys(directory = directory, overwrite = overwrite)
-    )
+    quiet_list_surveys <- purrr::quietly(.list_surveys)
+    quiet_list_surveys(directory = directory, overwrite = overwrite)
   }
 }
 

--- a/R/lists.R
+++ b/R/lists.R
@@ -19,7 +19,7 @@ list_surveys <- function(
     .list_surveys(directory = directory, overwrite = overwrite)
   } else {
     quiet_list_surveys <- purrr::quietly(.list_surveys)
-    quiet_list_surveys(directory = directory, overwrite = overwrite)
+    quiet_list_surveys(directory = directory, overwrite = overwrite)$result
   }
 }
 

--- a/tests/testthat/test-list-surveys.R
+++ b/tests/testthat/test-list-surveys.R
@@ -37,8 +37,9 @@ test_that("list_surveys() is verbose or silent when verbose = TRUE or FALSE", {
   skip_if_offline("zenodo.org")
   skip_on_cran()
   expect_silent(
-    . <- list_surveys(verbose = FALSE) # nolint
+    dat_silent <- list_surveys(verbose = FALSE) # nolint
   )
+  expect_s3_class(dat_silent, c("data.table", "data.frame"))
   expect_snapshot(
     . <- list_surveys(verbose = FALSE) # nolint
   )

--- a/tests/testthat/test-list-surveys.R
+++ b/tests/testthat/test-list-surveys.R
@@ -36,6 +36,9 @@ test_that("list_surveys() gives warnings when non-default directory used ", {
 test_that("list_surveys() is verbose or silent when verbose = TRUE or FALSE", {
   skip_if_offline("zenodo.org")
   skip_on_cran()
+  expect_silent(
+    . <- list_surveys(verbose = FALSE) # nolint
+  )
   expect_snapshot(
     . <- list_surveys(verbose = FALSE) # nolint
   )

--- a/tests/testthat/test-surveys.R
+++ b/tests/testthat/test-surveys.R
@@ -41,6 +41,9 @@ test_that("download_survey() is silent when verbose = FALSE", {
   skip_on_ci()
   doi_peru <- "10.5281/zenodo.1095664" # nolint
   Sys.sleep(5)
+  expect_silent(
+    . <- download_survey(doi_peru, verbose = FALSE) # nolint
+  )
   expect_snapshot(
     . <- download_survey(doi_peru, verbose = FALSE) # nolint
   )


### PR DESCRIPTION
While this does introduce a purrr dependency, I could not get the function to properly stay quiet without `purrr::quietly()`. We can revisit dependency reduction later, perhaps.

Resolves #68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Non-verbose mode is now truly silent: messages/warnings are captured internally while returning the same results (resolves #68).
- Documentation
  - Added NEWS entry announcing the verbosity fix.
- Tests
  - Added tests asserting no console output in non-verbose mode.
- Chores
  - Added purrr as a package dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->