### PR TITLE
Insistently download i73

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,3 +6,4 @@
 * Added bibtex citation style as default to `get_citation()` - Resolves #52
 * Fixed verbosity issue by importing purrr::quietly - Resolves #68
 * Improved cache management by avoiding unnecessary Zenodo API calls by storing each survey in a subdirectory named after the survey’s DOI/URL basename — Resolves #72
+* Added `rate` argument to `download_survey()` and `list_surveys()` to allow for retrying download if it fails, in a sensible fashion, using `purrr::insistently()` - Resolves #72

--- a/R/download_survey.R
+++ b/R/download_survey.R
@@ -16,8 +16,13 @@
 #' @param verbose Whether downloads should be echoed to output. Default TRUE.
 #' @param overwrite If files should be overwritten if they already exist.
 #'   Default FALSE
-#' @param timeout A numeric value specifying timeout in seconds. Default 60
-#'  seconds.
+#' @param timeout A numeric value specifying timeout in seconds. Default 3600 seconds.
+#' @param rate a
+#'   [purrr rate](https://purrr.tidyverse.org/reference/rate-helpers.html)
+#'   object, to facilitate downloading if the download fails. Defaults to an
+#'   exponential backoff of 5 seconds, retrying only 3 times. This can be
+#'   changed by specifying your own rate object, see `?purrr::rate_backoff()`
+#'   for details.
 #'
 #' @return a vector of filenames, where the surveys were downloaded
 #'
@@ -29,23 +34,30 @@
 #' }
 #' @seealso [list_surveys()]
 #' @importFrom zen4R get_zenodo
+#' @importFrom
 #' @export
 download_survey <- function(
   survey,
   directory = contactsurveys_dir(),
   verbose = TRUE,
   overwrite = FALSE,
-  timeout = 60
+  timeout = 3600,
+  rate = purrr::rate_backoff(pause_base = 5, max_times = 4)
 ) {
+  insistent_download_survey <- purrr::insistently(
+    f = .download_survey,
+    rate = rate,
+    quiet = FALSE
+  )
   if (verbose) {
-    .download_survey(
+    insistent_download_survey(
       survey = survey,
       directory = directory,
       overwrite = overwrite,
       timeout = timeout
     )
   } else {
-    quiet_download_survey <- purrr::quietly(.download_survey)
+    quiet_download_survey <- purrr::quietly(insistent_download_survey)
     quiet_download_survey(
       survey = survey,
       directory = directory,

--- a/R/download_survey.R
+++ b/R/download_survey.R
@@ -21,7 +21,8 @@
 #' @param verbose Whether downloads should be echoed to output. Default TRUE.
 #' @param overwrite If files should be overwritten if they already exist.
 #'   Default FALSE
-#' @param timeout A numeric value specifying timeout in seconds. Default 3600 seconds.
+#' @param timeout A numeric value specifying timeout in seconds. Default
+#'   3600 seconds.
 #' @param rate a
 #'   [purrr rate](https://purrr.tidyverse.org/reference/rate-helpers.html)
 #'   object, to facilitate downloading if the download fails. Defaults to an
@@ -39,7 +40,6 @@
 #' }
 #' @seealso [list_surveys()]
 #' @importFrom zen4R get_zenodo
-#' @importFrom
 #' @export
 download_survey <- function(
   survey,

--- a/R/download_survey.R
+++ b/R/download_survey.R
@@ -52,10 +52,10 @@ download_survey <- function(
   insistent_download_survey <- purrr::insistently(
     f = .download_survey,
     rate = rate,
-    quiet = FALSE
+    quiet = !isTRUE(verbose)
   )
   if (verbose) {
-    insistent_download_survey(
+    res <- insistent_download_survey(
       survey = survey,
       directory = directory,
       overwrite = overwrite,
@@ -63,13 +63,15 @@ download_survey <- function(
     )
   } else {
     quiet_download_survey <- purrr::quietly(insistent_download_survey)
-    quiet_download_survey(
+    res <- quiet_download_survey(
       survey = survey,
       directory = directory,
       overwrite = overwrite,
       timeout = timeout
     )$result
   }
+
+  res
 }
 
 #' @autoglobal

--- a/R/download_survey.R
+++ b/R/download_survey.R
@@ -26,7 +26,7 @@
 #' @param rate a
 #'   [purrr rate](https://purrr.tidyverse.org/reference/rate-helpers.html)
 #'   object, to facilitate downloading if the download fails. Defaults to an
-#'   exponential backoff of 5 seconds, retrying only 3 times. This can be
+#'   exponential backoff of 5 seconds (up to 4 attempts: 1 initial + 3 retries)
 #'   changed by specifying your own rate object, see `?purrr::rate_backoff()`
 #'   for details.
 #'

--- a/R/lists.R
+++ b/R/lists.R
@@ -13,12 +13,18 @@
 list_surveys <- function(
   directory = contactsurveys_dir(),
   overwrite = FALSE,
-  verbose = TRUE
+  verbose = TRUE,
+  rate = purrr::rate_backoff(pause_base = 5, max_times = 4)
 ) {
+  insistent_list_surveys <- purrr::insistently(
+    f = .list_surveys,
+    rate = rate,
+    quiet = !isTRUE(verbose)
+  )
   if (verbose) {
-    .list_surveys(directory = directory, overwrite = overwrite)
+    insistent_list_surveys(directory = directory, overwrite = overwrite)
   } else {
-    quiet_list_surveys <- purrr::quietly(.list_surveys)
+    quiet_list_surveys <- purrr::quietly(insistent_list_surveys)
     quiet_list_surveys(directory = directory, overwrite = overwrite)$result
   }
 }

--- a/man/download_survey.Rd
+++ b/man/download_survey.Rd
@@ -36,7 +36,8 @@ will be cached in separate directories by design.}
 \item{overwrite}{If files should be overwritten if they already exist.
 Default FALSE}
 
-\item{timeout}{A numeric value specifying timeout in seconds. Default 3600 seconds.}
+\item{timeout}{A numeric value specifying timeout in seconds. Default
+3600 seconds.}
 
 \item{rate}{a
 \href{https://purrr.tidyverse.org/reference/rate-helpers.html}{purrr rate}

--- a/man/download_survey.Rd
+++ b/man/download_survey.Rd
@@ -9,7 +9,8 @@ download_survey(
   directory = contactsurveys_dir(),
   verbose = TRUE,
   overwrite = FALSE,
-  timeout = 60
+  timeout = 3600,
+  rate = purrr::rate_backoff(pause_base = 5, max_times = 4)
 )
 }
 \arguments{
@@ -35,8 +36,14 @@ will be cached in separate directories by design.}
 \item{overwrite}{If files should be overwritten if they already exist.
 Default FALSE}
 
-\item{timeout}{A numeric value specifying timeout in seconds. Default 60
-seconds.}
+\item{timeout}{A numeric value specifying timeout in seconds. Default 3600 seconds.}
+
+\item{rate}{a
+\href{https://purrr.tidyverse.org/reference/rate-helpers.html}{purrr rate}
+object, to facilitate downloading if the download fails. Defaults to an
+exponential backoff of 5 seconds, retrying only 3 times. This can be
+changed by specifying your own rate object, see \code{?purrr::rate_backoff()}
+for details.}
 }
 \value{
 a vector of filenames, where the surveys were downloaded

--- a/man/download_survey.Rd
+++ b/man/download_survey.Rd
@@ -42,7 +42,7 @@ Default FALSE}
 \item{rate}{a
 \href{https://purrr.tidyverse.org/reference/rate-helpers.html}{purrr rate}
 object, to facilitate downloading if the download fails. Defaults to an
-exponential backoff of 5 seconds, retrying only 3 times. This can be
+exponential backoff of 5 seconds (up to 4 attempts: 1 initial + 3 retries)
 changed by specifying your own rate object, see \code{?purrr::rate_backoff()}
 for details.}
 }

--- a/man/list_surveys.Rd
+++ b/man/list_surveys.Rd
@@ -7,7 +7,8 @@
 list_surveys(
   directory = contactsurveys_dir(),
   overwrite = FALSE,
-  verbose = TRUE
+  verbose = TRUE,
+  rate = purrr::rate_backoff(pause_base = 5, max_times = 4)
 )
 }
 \arguments{
@@ -29,6 +30,13 @@ will be cached in separate directories by design.}
 Default FALSE}
 
 \item{verbose}{Whether downloads should be echoed to output. Default TRUE.}
+
+\item{rate}{a
+\href{https://purrr.tidyverse.org/reference/rate-helpers.html}{purrr rate}
+object, to facilitate downloading if the download fails. Defaults to an
+exponential backoff of 5 seconds (up to 4 attempts: 1 initial + 3 retries)
+changed by specifying your own rate object, see \code{?purrr::rate_backoff()}
+for details.}
 }
 \value{
 data.table with columns: date_added, title, creator, url


### PR DESCRIPTION
Resolves #73 by using `purrr::insistently()`. It can be a bit tricky to replicate behaviour where the API fails, but this should  make things a little more robust.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a retry mechanism with exponential backoff for survey downloads (configurable via a new rate parameter).

* **Improvements**
  * Increased default download timeout from 60 seconds to 1 hour for more reliable downloads.
  * Non-verbose mode now returns the list/vector of downloaded files for easier programmatic use.

* **Documentation**
  * Updated docs to document the new rate parameter and the revised timeout default and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->