### PR TITLE
Add tests for ls_contactsurveys()

### DIFF
--- a/R/list-contactsurvey-files.R
+++ b/R/list-contactsurvey-files.R
@@ -35,7 +35,7 @@ ls_contactsurveys <- function(dir = contactsurveys_dir()) {
 #' delete_contactsurveys_files()
 #' }
 delete_contactsurveys_files <- function(dir = contactsurveys_dir()) {
-  if (!dir.exists(dir)) {
+  if (!.dir.exists(dir)) {
     cli::cli_abort(
       c(
         "!" = "Directory not found: {dir}", # nolint

--- a/R/list-contactsurvey-files.R
+++ b/R/list-contactsurvey-files.R
@@ -36,13 +36,12 @@ ls_contactsurveys <- function(dir = contactsurveys_dir()) {
 #' }
 delete_contactsurveys_files <- function(dir = contactsurveys_dir()) {
   if (!dir.exists(dir)) {
-    cli::cli_inform(
+    cli::cli_abort(
       c(
         "!" = "Directory not found: {dir}", # nolint
         "i" = "Use {.fun contactsurveys_dir} to get the base path." # nolint
       )
     )
-    return(invisible(NULL))
   }
   dir_files <- ls_contactsurveys(dir)
   n_files <- length(dir_files)
@@ -80,7 +79,7 @@ delete_contactsurveys_files <- function(dir = contactsurveys_dir()) {
         "Removed {n_removed} of {n_files} file{?s} from {dir}"
       )
       if (length(failed) > 0) {
-        cli::cli_bullets(
+        cli::cli_warn(
           c(
             "x" = "Failed to remove:", # nolint
             stats::setNames(failed, rep("*", length(failed)))
@@ -88,9 +87,8 @@ delete_contactsurveys_files <- function(dir = contactsurveys_dir()) {
         )
       }
     }
-    return(invisible(n_removed))
   }
-  invisible(0L)
+  invisible(NULL)
 }
 
 #' @name delete-files

--- a/R/zzzz.R
+++ b/R/zzzz.R
@@ -1,2 +1,3 @@
-dir.exists <- NULL
-file.remove <- NULL
+# need to create a binding so we can mock these later in testing
+dir.exists <- base::dir.exists
+file.remove <- base::file.remove

--- a/R/zzzz.R
+++ b/R/zzzz.R
@@ -1,0 +1,2 @@
+dir.exists <- NULL
+file.remove <- NULL

--- a/R/zzzz.R
+++ b/R/zzzz.R
@@ -1,3 +1,2 @@
 # need to create a binding so we can mock these later in testing
-dir.exists <- base::dir.exists
-file.remove <- base::file.remove
+.dir.exists <- function(paths) base::dir.exists(paths)

--- a/tests/testthat/test-ls-contactsurveys.R
+++ b/tests/testthat/test-ls-contactsurveys.R
@@ -1,0 +1,24 @@
+test_that("ls_contactsurveys() works", {
+  file_paths <- ls_contactsurveys()
+  expect_true(all(file.exists(file_paths)))
+})
+
+test_that("delete_contactsurveys_files() errors", {
+  local_mocked_bindings(
+    dir.exists = function(paths) FALSE
+  )
+  expect_error(
+    delete_contactsurveys_files(),
+    "Directory not found"
+  )
+})
+
+test_that("delete_contactsurveys_files() messages", {
+  local_mocked_bindings(
+    ls_contactsurveys = function(dir) NULL
+  )
+  expect_message(
+    delete_contactsurveys_files(),
+    "There are no files to delete"
+  )
+})

--- a/tests/testthat/test-ls-contactsurveys.R
+++ b/tests/testthat/test-ls-contactsurveys.R
@@ -1,5 +1,6 @@
 test_that("ls_contactsurveys() works", {
   file_paths <- ls_contactsurveys()
+  expect_true(all(is.character(file_paths)))
   expect_true(all(file.exists(file_paths)))
 })
 
@@ -15,7 +16,8 @@ test_that("delete_contactsurveys_files() errors", {
 
 test_that("delete_contactsurveys_files() messages", {
   local_mocked_bindings(
-    ls_contactsurveys = function(dir) NULL
+    dir.exists = function(paths) TRUE,
+    ls_contactsurveys = function(dir) character(0)
   )
   expect_message(
     delete_contactsurveys_files(),

--- a/tests/testthat/test-ls-contactsurveys.R
+++ b/tests/testthat/test-ls-contactsurveys.R
@@ -6,7 +6,7 @@ test_that("ls_contactsurveys() works", {
 
 test_that("delete_contactsurveys_files() errors", {
   local_mocked_bindings(
-    dir.exists = function(paths) FALSE
+    .dir.exists = function(paths) FALSE
   )
   expect_error(
     delete_contactsurveys_files(),
@@ -16,7 +16,7 @@ test_that("delete_contactsurveys_files() errors", {
 
 test_that("delete_contactsurveys_files() messages", {
   local_mocked_bindings(
-    dir.exists = function(paths) TRUE,
+    .dir.exists = function(paths) TRUE,
     ls_contactsurveys = function(dir) character(0)
   )
   expect_message(


### PR DESCRIPTION
Improve test coverage
Resolves #83 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Stricter error handling: managing files in a missing survey directory now throws an error instead of silently returning.
  - Clearer partial-failure reporting with warnings when some files cannot be removed.
  - Standardized return behavior for deletion actions (no longer returns a count).

- Tests
  - Added tests to ensure listed survey files exist.
  - Verified error on missing survey directory.
  - Confirmed message when no files are available to delete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->